### PR TITLE
:sparkles: Generating ppm and add more options

### DIFF
--- a/include/Application.hpp
+++ b/include/Application.hpp
@@ -81,6 +81,7 @@ struct SceneUBO {
 class Application {
 protected:
     std::string _appName;
+    bool _running;
     glm::vec2 _windowSize{100, 100};
     GLFWwindow *_window;
     vk::Instance _instance;
@@ -197,6 +198,10 @@ public:
 
     void useCamera(std::size_t idx);
     void updateScene();
+    [[nodiscard]] std::size_t getFrameIndex() const;
+    vk::Image &getCurrentImage();
+    void screenshot(const std::string &filename);
+    void stop();
 protected:
     void initWindow();
     void initVulkan();
@@ -247,4 +252,5 @@ protected:
     void copyBuffer(vk::Buffer srcBuffer, vk::Buffer dstBuffer, vk::DeviceSize size);
     uint32_t findMemoryType(uint32_t typeFilter, vk::MemoryPropertyFlags properties);
     void drawFrame();
+    vk::CommandBuffer beginSingleTimeCommands();
 };

--- a/include/Raytracer.hpp
+++ b/include/Raytracer.hpp
@@ -1,0 +1,24 @@
+/*
+** EPITECH PROJECT, 2024
+** RTX
+** File description:
+** No file there , just an epitech header example .
+** You can even have multiple lines if you want !
+*/
+
+#ifndef RTX_RAYTRACER_HPP
+    #define RTX_RAYTRACER_HPP
+    #include <string>
+
+struct Arguments {
+    std::string scenePath;
+    std::string outputPath = "./screenshot.ppm";
+    int width = 800;
+    int height = 600;
+    bool quit_after_render = true;
+    bool disable_render_output = false;
+    std::size_t frame_before_render = 30;
+    bool quiet = false;
+};
+
+#endif // RTX_RAYTRACER_HPP

--- a/scenes/simple.json
+++ b/scenes/simple.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "skybox-enabled": true
+    "skybox-enabled": false
   },
   "cameras": [
     {

--- a/shaders/raytracing.comp
+++ b/shaders/raytracing.comp
@@ -218,7 +218,7 @@ vec3 raytrace(Ray ray, inout uint seed) {
             incomingLight += directLight * color;
             color *= hit.material.color;
         } else {
-            if (iIsSkyboxEnabled == 1) {
+            if (iIsSkyboxEnabled > 0) {
                 incomingLight += environmentLight(ray) * color;
             }
             break;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -19,6 +19,7 @@ Scene::Scene(Scene const &other)
 {
     _objects = other.getObjects();
     _cameras = other.getCameras();
+    _skyBoxEnabled = other.isSkyBoxEnabled();
 }
 
 Scene::~Scene()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,31 +10,119 @@
 #include "SceneParser.hpp"
 #include "primitives/Cube.hpp"
 #include "primitives/Rectangle.hpp"
+#include "Raytracer.hpp"
 #include <iostream>
+#include <fstream>
 
-#define WIDTH 800.0f
-#define HEIGHT 600.0f
+static Arguments parseArgs(int argc, char **argv)
+{
+    Arguments args;
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if (arg == "-f" || arg == "--fast" || arg == "--auto-quit") {
+            args.quit_after_render = true;
+        } else if (arg == "--frames") {
+            if (i + 1 >= argc) {
+                std::cerr << "Missing argument for --frames" << std::endl;
+                exit(84);
+            }
+            args.frame_before_render = std::stoi(argv[i + 1]);
+            if (args.frame_before_render < 1) {
+                std::cerr << "Invalid argument for --frames" << std::endl;
+                exit(84);
+            }
+            i++;
+        } else if (arg == "-x" || arg == "--disable-screenshot") {
+            args.disable_render_output = true;
+        } else if (arg == "-s" || arg == "--size") {
+            if (i + 1 >= argc) {
+                std::cerr << "Missing argument for --size" << std::endl;
+                exit(84);
+            }
+            std::string size = argv[i + 1];
+            size_t pos = size.find('x');
+            if (pos == std::string::npos) {
+                std::cerr << "Invalid size format" << std::endl;
+                exit(84);
+            }
+            args.width = std::stoi(size.substr(0, pos));
+            args.height = std::stoi(size.substr(pos + 1));
+            i++;
+        } else if (arg == "-h" || arg == "--help") {
+            std::cerr << "Usage: ./raytracer \"scene file\"" << std::endl;
+            std::cerr << "Options:" << std::endl;
+            std::cerr << "  -f --fast --auto-quit: Automatically quit after the screenshot is taken" << std::endl;
+            std::cerr << "  --frames N: Set the number of frame before taking the screenshot" << std::endl;
+            std::cerr << "  -x --disable-screenshot: Disable the screenshot" << std::endl;
+            std::cerr << "  -s --size WIDTHxHEIGHT: Set the size of the window" << std::endl;
+            std::cerr << "  -o --output PATH: Set the output path of the screenshot" << std::endl;
+            std::cerr << "  -q --quiet: Disable warning messages" << std::endl;
+            std::cerr << "  -h --help: Display this help message" << std::endl;
+            exit(0);
+        } else if (arg == "-o" || arg == "--output") {
+            if (i + 1 >= argc) {
+                std::cerr << "Missing argument for --output" << std::endl;
+                exit(84);
+            }
+            args.outputPath = argv[i + 1];
+            i++;
+        } else if (arg == "-q" || arg == "--quiet") {
+            args.quiet = true;
+        } else {
+            if (arg[0] == '-') {
+                std::cerr << "Unknown option: " << arg << std::endl;
+                exit(84);
+            }
+            args.scenePath = arg;
+        }
+    }
+    return args;
+}
+
+static void checkOverwritingOutput(const std::string &outputPath, bool quiet)
+{
+    std::ifstream file(outputPath);
+    if (file.is_open()) {
+        if (!quiet) {
+            std::cerr << "Caution: " << outputPath << " already exists, it will be overwritten" << std::endl;
+            std::cerr << "To disable this message, use -q or --quiet" << std::endl;
+        }
+        file.close();
+    }
+}
 
 int main(int argc, char **argv)
 {
-    if (argc != 2) {
-        std::cerr << "Usage: ./rtx \"scene file\"" << std::endl;
+    Arguments args = parseArgs(argc, argv);
+    if (args.scenePath.empty()) {
+        std::cerr << "Missing scene file" << std::endl;
         return 84;
     }
+    checkOverwritingOutput(args.outputPath, args.quiet);
     ObjectsFactory objFactory = ObjectsFactory();
     PropertiesFactory propFactory = PropertiesFactory();
     objFactory.registerObject("cube", [](AbstractProperties &properties) -> Object * {return new Cube(dynamic_cast<CubeProperties &>(properties));});
     objFactory.registerObject("rectangle", [](AbstractProperties &properties) -> Object * {return new Rectangle(dynamic_cast<RectangleProperties &>(properties));});
     propFactory.registerProperties("cube", [](JsonObject *obj) { return new CubeProperties(obj); });
     propFactory.registerProperties("rectangle", [](JsonObject *obj) { return new RectangleProperties(obj); });
-    std::string path = std::string(argv[1]);
+    std::string path = std::string(args.scenePath);
     SceneParser parser = SceneParser(path, propFactory, objFactory);
     parser.parse();
     Scene scene = parser.getScene();
 
-    Application app(WIDTH, HEIGHT, "RTX", &scene);
+    Application app(args.width, args.height, "RTX", &scene);
 
-    app.run([&scene]() {
+    bool saved = false;
+
+    app.run([&app, &saved, &args]() {
+        if (app.getFrameIndex() >= args.frame_before_render && !saved && !args.disable_render_output) {
+            app.screenshot(args.outputPath);
+            saved = true;
+
+            if (args.quit_after_render) {
+                app.stop();
+            }
+        }
     });
     return 0;
 }


### PR DESCRIPTION
I added a couple of options, you can see all of them with -h or --help.
I also added the ppm generation, you can choose the output path.

The ppm generation is flexible, so if we want to add a key bind that triggers it many times during the runtime we will be able to.